### PR TITLE
Update gdscript style.md

### DIFF
--- a/guides/gdscript style.md
+++ b/guides/gdscript style.md
@@ -1,19 +1,22 @@
 # GDScript Style Guide
 
-### Description
-This document describes a set of conventions for GDScript code style. The goal is to encourage writing clean, readable code and promote consistency across projects, discussions, and tutorials. Since GDScript is heavily influenced by Python, this guide is inspired by and takes many suggestions from [PEP 8](https://www.python.org/dev/peps/pep-0008/).
+## Description
 
-Hopefully, as the Godot community grows, this will also encourage development of auto-formatting tools.
+This styleguide lists conventions to write elegant GDScript. The goal is to encourage writing clean, readable code and promote consistency across projects, discussions, and tutorials. Hopefully, this will also encourage development of auto-formatting tools.
 
-_Note:_ Many of these guidelines are encouraged by Godot's built-in script editor's default settings. Let it help you.
+Since GDScript is close to Python, this guide is inspired by Python's [PEP 8](https://www.python.org/dev/peps/pep-0008/) programming styleguide.
 
-### Code Structure
+_Note:_ Godot's built-in script editor's uses a lot of these conventions by default. Let it help you.
 
-#### Indentation
+## Code Structure
+
+### Indentation
+
 Indent type: Tabs _(editor default)_
+
 Indent size: 4 _(editor default)_
 
-Each indentation level should be one greater than the block containing it.
+Each indent level should be one greater than the block containing it.
 
 **Good**
 ```
@@ -27,7 +30,7 @@ for i in range(10):
         print("hello")
 ```
 
-Continuation of long lines should use at least two indent levels to distinguish it from a regular code block.
+Use at least 2 indent levels to distinguish continuation lines from regular code blocks.
 
 **Good**
 ```
@@ -43,15 +46,15 @@ effect.interpolate_property(sprite, 'transform/scale',
     Tween.TRANS_QUAD, Tween.EASE_OUT)
 ```
 
-#### Blank lines
+### Blank lines
 
-Function and class definitions should be surrounded by a blank line.
+Surround functions and class definitions by a blank line.
 
-Use blank lines where appropriate inside functions to separate logical sections.
+Use one blank line inside functions to separate logical sections.
 
-#### One Statement per line
+### One Statement per line
 
-Never combine multiple statements on a single line. No, C programmers, not even when you have a single line conditional statement!
+Never combine multiple statements on a single line. No, C programmers, not with a single line conditional statement (except with the ternary operator)!
 
 **Good**
 ```
@@ -69,25 +72,25 @@ if position.x > width: position.x = 0
 if flag: print("flagged")
 ```
 
-#### Avoid Unnecessary Parentheses
+### Avoid Unnecessary Parentheses
 
-Avoid using parentheses in expressions and conditional statements. Unless necessary for order of operations, they add nothing and reduce readability.
+Avoid parentheses in expressions and conditional statements. Unless necessary for order of operations, they only reduce readability.
 
 **Good**
 ```
 if is_colliding():
     queue_free()
-````
+```
 **Bad**
 ```
 if (is_colliding()):
     queue_free()
-````
+```
 
 
-#### Whitespace
+### Whitespace
 
-One space should always be used around operators and after commas. Avoid extra spaces in dictionary references and function calls.
+Always use one space around operators and after commas. Avoid extra spaces in dictionary references and function calls.
 
 **Good**
 ```
@@ -121,18 +124,22 @@ c = a*a + b*b     # good
 c = a * a + b * b # bad
 ```
 
-### Other
 
-### Naming Conventions
+
+## Naming Conventions
+
 These naming conventions follow the Godot Engine style. Breaking these will make your code clash with the built-in naming conventions, which is ugly.
 
-#### Classes and Nodes
-Class names use CapWords: `KinematicBody`
+### Classes and Nodes
 
-#### Functions and Variables
-Function and variable names use snake_case: `get_node()`
+Use CapWords, or PascalCase: `extends KinematicBody`
 
-Private functions and variables may be designated by a single leading underscore: `_ready()`
+### Functions and Variables
 
-#### Constants
-Constants should generally be named using ALL_CAPS: `MAX_SPEED`
+Use snake_case: `get_node()`
+
+Prepend a single underscore (\_) to virtual methods (functions the user must override), private functions and private variables: `func _ready()`
+
+### Constants
+
+Use CONSTANT\_CASE, all caps, with an underscore (\_) to separate words: `const MAX_SPEED = 200`


### PR DESCRIPTION
- add blank lines to delimit paragraphs. Github doesn't care but other markdown processors do.
- fix title levels, there was a jump from h1 to h3
- change the text's style to be more direct. E.g. "You should use" -> "Use"
- change a sentence from passive to direct voice
- simplify Naming Conventions: each title tells what the paragraph is about
- add a note about virtual methods: by convention, the leading underscore is for virtual methods in GDscript - Karroffel told me it was not related to Python